### PR TITLE
Fix: Load operators on page mount for edit building dropdown

### DIFF
--- a/src/app/admin/data-management/page.tsx
+++ b/src/app/admin/data-management/page.tsx
@@ -209,9 +209,22 @@ export default function DataManagementPage({}: DataManagementPageProps) {
     }
   }
 
-  // Fetch total counts on component mount
+  // Fetch operators list for dropdowns (needed by edit modals)
+  const fetchOperatorsForDropdowns = async () => {
+    try {
+      const response = await operatorsService.list({ limit: 1000 }) // Get all operators
+      if (response.success && response.data) {
+        setOperators(response.data)
+      }
+    } catch (error) {
+      console.error('Failed to fetch operators for dropdowns:', error)
+    }
+  }
+
+  // Fetch total counts and operators on component mount
   useEffect(() => {
     fetchTotalCounts()
+    fetchOperatorsForDropdowns()
   }, [])
 
   // Refresh data when dependencies change


### PR DESCRIPTION
Issue: Building Manager dropdown was empty when editing buildings because operators were only fetched when on the Operators tab.

Solution: Fetch all operators when page loads, so they're available for the Building edit modal dropdown regardless of active tab.

Changes:
- Added fetchOperatorsForDropdowns() function
- Fetch operators on component mount (useEffect)
- Operators now always available for edit modal dropdowns
